### PR TITLE
fix: mcp-server's env will fill env from default

### DIFF
--- a/services/connectServer.ts
+++ b/services/connectServer.ts
@@ -1,5 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { getDefaultEnvironment, StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SystemCommandManager } from "./syscmd/index.js";
 import logger from "./utils/logger.js";
 import { iServerConfig } from "./utils/types.js";
@@ -8,23 +8,21 @@ import { iServerConfig } from "./utils/types.js";
 export async function handleConnectToServer(
   serverName: string,
   serverConfig: iServerConfig,
+  allSpecificEnv: any
 ) {
   logger.debug(`============`);
   logger.debug(`Runtime Platform: ${process.platform}`);
   logger.debug(`Attempting to connect to server: ${serverName}`);
   // Check specific command 'node'
   serverConfig.command = SystemCommandManager.getInstance().getValue(serverConfig.command) || serverConfig.command;
-  serverConfig.env = process.platform === 'win32' ? { ...serverConfig.env, PYTHONIOENCODING: "utf-8" } : serverConfig.env;
-
-  if (serverConfig.env && !Object.keys(serverConfig.env).length) {
-    serverConfig.env = undefined;
-  }
+  const allSpecificEnv_ = process.platform === 'win32' ? { ...allSpecificEnv, PYTHONIOENCODING: "utf-8" } : allSpecificEnv;
+  const defaultEnv = getDefaultEnvironment();
 
   // Establish transport
   const transport = new StdioClientTransport({
     command: serverConfig.command,
     args: serverConfig.args,
-    env: serverConfig.env,
+    env: { ...defaultEnv, ...allSpecificEnv_ },
   });
 
   // Debug logs

--- a/services/mcpServer/index.ts
+++ b/services/mcpServer/index.ts
@@ -52,9 +52,13 @@ export class MCPServerManager implements IMCPServerManager {
     const { config, servers } = await loadConfigAndServers(this.configPath);
     logger.info(`Connect to ${servers.length} enabled servers...`);
 
+    const allSpecificEnv = Object.values(config.mcpServers).reduce((acc, server) => {
+      return { ...acc, ...server.env };
+    }, {});
+
     // async connect all servers
     const connectionResults = await Promise.allSettled(
-      servers.map((serverName) => this.connectSingleServer(serverName, config.mcpServers[serverName]))
+      servers.map((serverName) => this.connectSingleServer(serverName, config.mcpServers[serverName], allSpecificEnv))
     );
 
     // collect error
@@ -89,10 +93,11 @@ export class MCPServerManager implements IMCPServerManager {
 
   async connectSingleServer(
     serverName: string,
-    config: iServerConfig
+    config: iServerConfig,
+    allSpecificEnv: any
   ): Promise<{ success: boolean; serverName: string; error?: unknown }> {
     try {
-      const { client, transport } = await handleConnectToServer(serverName, config);
+      const { client, transport } = await handleConnectToServer(serverName, config, allSpecificEnv);
       this.servers.set(serverName, client);
       this.transports.set(serverName, transport);
 

--- a/services/mcpServer/interface.ts
+++ b/services/mcpServer/interface.ts
@@ -18,6 +18,7 @@ export interface IMCPServerManager {
   connectSingleServer(
     serverName: string,
     config: iServerConfig,
+    allSpecificEnv: any,
   ): Promise<{ success: boolean; serverName: string; error?: unknown }>;
   syncServersWithConfig(): Promise<{ serverName: string; error: unknown }[]>;
 


### PR DESCRIPTION
fix: mcp-server's env will fill env from default