### PR TITLE
fix: handle zero values for model configuration parameters

### DIFF
--- a/src/components/ModelConfigForm.tsx
+++ b/src/components/ModelConfigForm.tsx
@@ -124,6 +124,14 @@ const ModelConfigForm: React.FC<ModelConfigFormProps> = ({
         delete (formData as any).baseURL
         delete (configuration as any).baseURL
       }
+      
+      if (formData.topP === 0) {
+        delete (formData as any).topP
+      }
+      
+      if (formData.temperature === 0) {
+        delete (formData as any).temperature
+      }
 
       const response = await fetch("/api/modelVerify", {
         method: "POST",
@@ -184,6 +192,14 @@ const ModelConfigForm: React.FC<ModelConfigFormProps> = ({
     if (!validateForm())
       return
     
+    if (formData.topP === 0) {
+      delete (formData as any).topP
+    }
+    
+    if (formData.temperature === 0) {
+      delete (formData as any).temperature
+    }
+    
     try {
       setIsSubmitting(true)
       const data = await saveConfig({ formData, provider })
@@ -207,7 +223,7 @@ const ModelConfigForm: React.FC<ModelConfigFormProps> = ({
       setIsVerified(false)
     }
   }
-
+  
   const validateForm = () => {
     const newErrors: Record<string, string> = {}
     Object.entries(fields).forEach(([key, field]) => {


### PR DESCRIPTION
When top-p and temperature are set to 0, these two fields are not sent.